### PR TITLE
Fix resolution of modules with multiple dots in their filename

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -45,7 +45,6 @@ function checkFilename (request, absolutePath) {
       }
       return absolutePath
     }
-    throw new Error('Cannot find module \'' + request + '\'')
   }
   if (fs.existsSync(absolutePath + '.js') && fs.statSync(absolutePath + '.js').isFile()) return absolutePath + '.js'
   if (fs.existsSync(absolutePath + '.json') && fs.statSync(absolutePath + '.json').isFile()) return absolutePath + '.json'


### PR DESCRIPTION
The existence of a dot in the filename does not mean that we can always skip checking for filename + '.js'.

Concrete example: Take a module with a filename `lib.dom.js` and a `require('./lib.dom')`. That's valid and should resolve to `./lib.dom.js`.

Btw, thanks for providing this handy package! I think the only reason that there aren't more stars on this repo is that the ASAR format is not too well known 😉