### PR TITLE
fix: recursion error (max call stack size exceeded)

### DIFF
--- a/lib/fs-wrapper.js
+++ b/lib/fs-wrapper.js
@@ -303,7 +303,7 @@ function overwriteFs () {
   overwrite('statSync', (statSync) => {
     return function (p, options) {
       p = bufferToString(p)
-      const pathInfo = options?.outsideAsar ? { isAsar: false } : splitPath(path.resolve(p))
+      const pathInfo = splitPath(path.resolve(p))
       const { isAsar, asarPath, filePath } = pathInfo
       if (!isAsar) return statSync.apply(this, arguments)
 
@@ -347,7 +347,7 @@ function overwriteFs () {
   overwrite('lstatSync', (lstatSync) => {
     return function (p, options) {
       p = bufferToString(p)
-      const { isAsar, asarPath, filePath } = options?.outsideAsar ? { isAsar: false } : splitPath(path.resolve(p))
+      const { isAsar, asarPath, filePath } = splitPath(path.resolve(p))
 
       if (!isAsar) return lstatSync.apply(this, arguments)
       const archive = getOrCreateArchive(asarPath)

--- a/lib/fs-wrapper.js
+++ b/lib/fs-wrapper.js
@@ -303,7 +303,7 @@ function overwriteFs () {
   overwrite('statSync', (statSync) => {
     return function (p, options) {
       p = bufferToString(p)
-      const pathInfo = splitPath(path.resolve(p))
+      const pathInfo = options?.outsideAsar ? { isAsar: false } : splitPath(path.resolve(p))
       const { isAsar, asarPath, filePath } = pathInfo
       if (!isAsar) return statSync.apply(this, arguments)
 
@@ -347,7 +347,7 @@ function overwriteFs () {
   overwrite('lstatSync', (lstatSync) => {
     return function (p, options) {
       p = bufferToString(p)
-      const { isAsar, asarPath, filePath } = splitPath(path.resolve(p))
+      const { isAsar, asarPath, filePath } = options?.outsideAsar ? { isAsar: false } : splitPath(path.resolve(p))
 
       if (!isAsar) return lstatSync.apply(this, arguments)
       const archive = getOrCreateArchive(asarPath)

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -1,5 +1,5 @@
 const {
-  statSync,
+  lstatSync,
   existsSync,
   openSync,
   readSync,
@@ -43,7 +43,7 @@ function splitPath (archivePath) {
   if (isAsarDisabled()) return r
   if (typeof archivePath !== 'string') return r
   if (archivePath.endsWith('.asar')) {
-    if (existsSync(archivePath) && statSync(archivePath, { outsideAsar: true }).isFile()) {
+    if (existsSync(archivePath) && lstatSync(archivePath).isFile()) {
       r.isAsar = true
       r.asarPath = tryRedirectUnpacked(archivePath)
       r.filePath = ''
@@ -57,7 +57,7 @@ function splitPath (archivePath) {
 
   const archive = archivePath.substring(0, index + 5)
 
-  if (existsSync(archive) && statSync(archive).isFile()) {
+  if (existsSync(archive) && lstatSync(archive).isFile()) {
     r.isAsar = true
     r.asarPath = tryRedirectUnpacked(archive)
     r.filePath = archivePath.substring(index + 6)

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -43,7 +43,7 @@ function splitPath (archivePath) {
   if (isAsarDisabled()) return r
   if (typeof archivePath !== 'string') return r
   if (archivePath.endsWith('.asar')) {
-    if (existsSync(archivePath) && statSync(archivePath).isFile()) {
+    if (existsSync(archivePath) && statSync(archivePath, { outsideAsar: true }).isFile()) {
       r.isAsar = true
       r.asarPath = tryRedirectUnpacked(archivePath)
       r.filePath = ''


### PR DESCRIPTION
Hi @toyobayashi,
I just updated my application from electron 17 to electron 20 and I suddenly started to get a `Maximum call stack size exceeded` error.
I don't have the exact stack trace anymore, but [`splitPath`](https://github.com/toyobayashi/asar-node/blob/571dcad5ea68cf42b94a2b4b71d3c247b84f7941/lib/util/index.js#L39) calls [`statSync`](https://github.com/toyobayashi/asar-node/blob/571dcad5ea68cf42b94a2b4b71d3c247b84f7941/lib/util/index.js#L46) and this calles [`splitPath`](https://github.com/toyobayashi/asar-node/blob/571dcad5ea68cf42b94a2b4b71d3c247b84f7941/lib/fs-wrapper.js#L306) again... This will go on forever until the maximum call stack size is exceeded.

I don't know what introduced this problem since I did not update `asar-node`, just other packages.
This PR, however, seems to fix it, although I don't know if that has sideeffects.